### PR TITLE
validate path before saving

### DIFF
--- a/path-manager/app/services/PathStore.scala
+++ b/path-manager/app/services/PathStore.scala
@@ -1,9 +1,21 @@
 package services
 
+import java.util.regex.Pattern
+
 import model.PathRecord
 import play.api.Logger
+
 import scala.collection.JavaConversions._
-import com.amazonaws.services.dynamodbv2.document.{AttributeUpdate, KeyAttribute, RangeKeyCondition, Item}
+import com.amazonaws.services.dynamodbv2.document.{AttributeUpdate, Item, KeyAttribute, RangeKeyCondition}
+
+import scala.util.matching.Regex
+
+object PathValidator {
+  def isValid(path: String): Boolean = {
+    val re = new Regex("^[a-z0-9]+(/[a-z0-9-]+)*$")
+    re.pattern.matcher(path).matches()
+  }
+}
 
 object PathStore {
 
@@ -11,25 +23,29 @@ object PathStore {
 
     Logger.debug(s"Registering new path [$path]")
 
-    val existingPath = Option(Dynamo.pathsTable.getItem("path", path)).map(PathRecord(_))
+    if (!PathValidator.isValid(path)) {
+      Left(s"invalid path [$path]")
+    } else {
+      val existingPath = Option(Dynamo.pathsTable.getItem("path", path)).map(PathRecord(_))
 
-    existingPath match {
-      case Some(pr) => {
-        Logger.warn(s"Failed to register new path [$path], already claimed by id [${pr.identifier}]")
-        Left("path already in use")
-      }
-      case None => {
-        val id = IdentifierSequence.getNextId
-        Logger.debug(s"generated id [$id] path [$path]")
-        val pathRecord = PathRecord(path, id, "canonical", system)
-        val shortUrlPathRecord = PathRecord(ShortUrlEncoder.generateShortUrlPath(id), id, "short", system)
+      existingPath match {
+        case Some(pr) => {
+          Logger.warn(s"Failed to register new path [$path], already claimed by id [${pr.identifier}]")
+          Left("path already in use")
+        }
+        case None => {
+          val id = IdentifierSequence.getNextId
+          Logger.debug(s"generated id [$id] path [$path]")
+          val pathRecord = PathRecord(path, id, "canonical", system)
+          val shortUrlPathRecord = PathRecord(ShortUrlEncoder.generateShortUrlPath(id), id, "short", system)
 
-        putPathItemAndAwaitIndexUpdate(pathRecord)
-        Logger.debug(s"Adding new short url record for [$id]. short path[${shortUrlPathRecord.path }]")
-        Dynamo.pathsTable.putItem(shortUrlPathRecord.asDynamoItem)
+          putPathItemAndAwaitIndexUpdate(pathRecord)
+          Logger.debug(s"Adding new short url record for [$id]. short path[${shortUrlPathRecord.path }]")
+          Dynamo.pathsTable.putItem(shortUrlPathRecord.asDynamoItem)
 
-        Logger.debug(s"Registered path [$path}] for id [$id] successfully")
-        Right(List(pathRecord, shortUrlPathRecord).groupBy(_.`type`))
+          Logger.debug(s"Registered path [$path}] for id [$id] successfully")
+          Right(List(pathRecord, shortUrlPathRecord).groupBy(_.`type`))
+        }
       }
     }
   }
@@ -40,35 +56,39 @@ object PathStore {
 
     Logger.debug(s"Registering path [${proposedPathRecord.path }] for [$id]")
 
-    val existingPath = Option(Dynamo.pathsTable.getItem("path", proposedPathRecord.path)).map(PathRecord(_))
-    val canonicalPathsForId = Dynamo.pathsTable.getIndex("id-index").query(new KeyAttribute("identifier", id), new RangeKeyCondition("type").eq("canonical"))
-    val existingCanonicalPathForId = canonicalPathsForId.map{ PathRecord(_) }.headOption
+    if (!PathValidator.isValid(proposedPathRecord.path)) {
+      Left(s"invalid path [${proposedPathRecord.path}]")
+    } else {
+      val existingPath = Option(Dynamo.pathsTable.getItem("path", proposedPathRecord.path)).map(PathRecord(_))
+      val canonicalPathsForId = Dynamo.pathsTable.getIndex("id-index").query(new KeyAttribute("identifier", id), new RangeKeyCondition("type").eq("canonical"))
+      val existingCanonicalPathForId = canonicalPathsForId.map{ PathRecord(_) }.headOption
 
-    existingPath match {
-      case Some(pr) if (pr.identifier != id) => {
-        Logger.warn(s"Failed to register existing path [${proposedPathRecord.path}], already claimed by id [${pr.identifier}], submitting id [$id]")
-        Left("path already in use")
-      }
-      case _ => {
-        val shortUrlPathRecord = PathRecord(ShortUrlEncoder.generateShortUrlPath(id), id, "short", proposedPathRecord.system)
+      existingPath match {
+        case Some(pr) if (pr.identifier != id) => {
+          Logger.warn(s"Failed to register existing path [${proposedPathRecord.path}], already claimed by id [${pr.identifier}], submitting id [$id]")
+          Left("path already in use")
+        }
+        case _ => {
+          val shortUrlPathRecord = PathRecord(ShortUrlEncoder.generateShortUrlPath(id), id, "short", proposedPathRecord.system)
 
-        existingCanonicalPathForId match {
-          case Some(oldCanonical) => {
-            if (oldCanonical.path != proposedPathRecord.path) {
-              Logger.debug(s"Removing old path for item [$id]. old path[${oldCanonical.path}] new path [${proposedPathRecord.path}]")
-              Dynamo.pathsTable.deleteItem("path", oldCanonical.path)
+          existingCanonicalPathForId match {
+            case Some(oldCanonical) => {
+              if (oldCanonical.path != proposedPathRecord.path) {
+                Logger.debug(s"Removing old path for item [$id]. old path[${oldCanonical.path}] new path [${proposedPathRecord.path}]")
+                Dynamo.pathsTable.deleteItem("path", oldCanonical.path)
+              }
+            }
+            case None => {
+              Logger.debug(s"Adding new short url record for [$id]. short path[${shortUrlPathRecord.path}]")
+              Dynamo.pathsTable.putItem(shortUrlPathRecord.asDynamoItem)
             }
           }
-          case None => {
-            Logger.debug(s"Adding new short url record for [$id]. short path[${shortUrlPathRecord.path}]")
-            Dynamo.pathsTable.putItem(shortUrlPathRecord.asDynamoItem)
-          }
+
+          putPathItemAndAwaitIndexUpdate(proposedPathRecord)
+
+          Logger.debug(s"Registered path [${proposedPathRecord.path}] for id [$id] successfully")
+          Right(List(proposedPathRecord, shortUrlPathRecord).groupBy(_.`type`))
         }
-
-        putPathItemAndAwaitIndexUpdate(proposedPathRecord)
-
-        Logger.debug(s"Registered path [${proposedPathRecord.path}] for id [$id] successfully")
-        Right(List(proposedPathRecord, shortUrlPathRecord).groupBy(_.`type`))
       }
     }
   }
@@ -76,31 +96,36 @@ object PathStore {
   def updateCanonical(newPath: String, id: Long) = {
 
     Logger.debug(s"Updating canonical path [$newPath}] for [$id]")
-    val newPathRecord = Option(Dynamo.pathsTable.getItem("path", newPath)).map(PathRecord(_))
-    val canonicalPathsForId = Dynamo.pathsTable.getIndex("id-index").query(new KeyAttribute("identifier", id), new RangeKeyCondition("type").eq("canonical"))
-    val canonicalPathForId = canonicalPathsForId.map{ PathRecord(_) }.headOption
 
-    if(newPathRecord.exists(_.identifier != id)) {
-      Logger.warn(s"Failed to update path [$newPath], already claimed by id [${newPathRecord.map{_.identifier}.get}], submitting id [$id]")
-      Left("path already in use")
+    if (!PathValidator.isValid(newPath)) {
+      Left(s"invalid path [$newPath]")
     } else {
-      canonicalPathForId.map { existingRecord: PathRecord =>
+      val newPathRecord = Option(Dynamo.pathsTable.getItem("path", newPath)).map(PathRecord(_))
+      val canonicalPathsForId = Dynamo.pathsTable.getIndex("id-index").query(new KeyAttribute("identifier", id), new RangeKeyCondition("type").eq("canonical"))
+      val canonicalPathForId = canonicalPathsForId.map{ PathRecord(_) }.headOption
 
-        val existingPath = existingRecord.path
-        val updatedRecord = if (existingPath != newPath) {
-            val newRecord = existingRecord.copy(path = newPath)
-            Logger.debug(s"Removing old path for item [$id]. old path[$existingPath] new path [$newPath]")
-            Dynamo.pathsTable.deleteItem("path", existingPath)
-            putPathItemAndAwaitIndexUpdate(newRecord)
-            newRecord
-          } else {
-            existingRecord
-          }
-        Logger.debug(s"updated canonical path [$newPath}] for id [$id] successfully")
-        List(updatedRecord).groupBy(_.`type`)
-      }.toRight{
-        Logger.warn(s"Failed to update path [$newPath], no existing path found for id [$id]")
-        s"unable to find canonical record for $id"
+      if(newPathRecord.exists(_.identifier != id)) {
+        Logger.warn(s"Failed to update path [$newPath], already claimed by id [${newPathRecord.map{_.identifier}.get}], submitting id [$id]")
+        Left("path already in use")
+      } else {
+        canonicalPathForId.map { existingRecord: PathRecord =>
+
+          val existingPath = existingRecord.path
+          val updatedRecord = if (existingPath != newPath) {
+              val newRecord = existingRecord.copy(path = newPath)
+              Logger.debug(s"Removing old path for item [$id]. old path[$existingPath] new path [$newPath]")
+              Dynamo.pathsTable.deleteItem("path", existingPath)
+              putPathItemAndAwaitIndexUpdate(newRecord)
+              newRecord
+            } else {
+              existingRecord
+            }
+          Logger.debug(s"updated canonical path [$newPath}] for id [$id] successfully")
+          List(updatedRecord).groupBy(_.`type`)
+        }.toRight{
+          Logger.warn(s"Failed to update path [$newPath], no existing path found for id [$id]")
+          s"unable to find canonical record for $id"
+        }
       }
     }
   }

--- a/path-manager/app/services/PathStore.scala
+++ b/path-manager/app/services/PathStore.scala
@@ -1,19 +1,17 @@
 package services
 
-import java.util.regex.Pattern
-
+import com.amazonaws.services.dynamodbv2.document.{KeyAttribute, RangeKeyCondition}
 import model.PathRecord
 import play.api.Logger
 
 import scala.collection.JavaConversions._
-import com.amazonaws.services.dynamodbv2.document.{AttributeUpdate, Item, KeyAttribute, RangeKeyCondition}
-
 import scala.util.matching.Regex
 
 object PathValidator {
+  val validPathRegex = new Regex("^[a-z0-9]+(/[a-z0-9-]+)*$")
+
   def isValid(path: String): Boolean = {
-    val re = new Regex("^[a-z0-9]+(/[a-z0-9-]+)*$")
-    re.pattern.matcher(path).matches()
+    validPathRegex.pattern.matcher(path).matches()
   }
 }
 

--- a/path-manager/test/services/PathValidatorTest.scala
+++ b/path-manager/test/services/PathValidatorTest.scala
@@ -1,0 +1,36 @@
+package services
+
+import org.scalatestplus.play._
+
+class PathValidatorTest extends PlaySpec {
+  "Path Validator" must {
+    "accept hyphenated alphanumeric paths" in {
+      PathValidator.isValid("path/to/something") must be(true)
+      PathValidator.isValid("path/to/something-else") must be(true)
+      PathValidator.isValid("global/2018/foo-bar") must be(true)
+      PathValidator.isValid("p/2nfpb") must be(true)
+    }
+
+    "reject a path starting with a hyphen" in {
+      PathValidator.isValid("-in/valid") must be(false)
+    }
+
+    "reject a path starting with a slash" in {
+      PathValidator.isValid("/some/content") must be(false)
+    }
+
+    "reject paths with white space" in {
+      PathValidator.isValid("path/to/some thing") must be(false)
+      PathValidator.isValid("path/to/some thing else") must be(false)
+    }
+
+    "reject paths with single quotes" in {
+      PathValidator.isValid("path/to/'something'") must be(false)
+      PathValidator.isValid("path/to/'something'-else") must be(false)
+    }
+
+    "reject paths with a combination of single quotes and white space" in {
+      PathValidator.isValid("path/to/'something' else-news") must be(false)
+    }
+  }
+}


### PR DESCRIPTION
We've seen some paths being created with whitespace, which isn't great, so explicitly reject invalid paths.

A valid path is one that's a hyphenated alphanumeric.

An invalid path:
- doesn't start with an alphanumeric
- contains white space
- contains single quotes

Failure will cause flexible-api to [return a `409`](https://github.com/guardian/flexible-content/blob/master/flexible-content-api/src/main/scala/com/gu/flexiblecontent/api/dispatcher/ApiDispatcher.scala#L1658-L1663) with response `invalid-identifier`, which is already handled by Composer [here](https://github.com/guardian/flexible-content/blob/master/composer/src/js/controllers/content/common/status.js#L124-L126).

Its easier to view the diff without whitespace - https://github.com/guardian/path-manager/pull/23/files?w=1