### PR TITLE
allow hyphens at the start of the url

### DIFF
--- a/path-manager/app/services/PathStore.scala
+++ b/path-manager/app/services/PathStore.scala
@@ -8,10 +8,12 @@ import scala.collection.JavaConversions._
 import scala.util.matching.Regex
 
 object PathValidator {
-  val validPathRegex = new Regex("^[a-z0-9]+(/[a-z0-9-]+)*$")
+  val validPathRegex = new Regex("^[a-z0-9][a-z0-9-]*(/[a-z0-9-]+)*$")
 
   def isValid(path: String): Boolean = {
-    validPathRegex.pattern.matcher(path).matches()
+    val matches = validPathRegex.pattern.matcher(path).matches()
+    if (!matches) Logger.warn(s"path fails validation [$path]")
+    matches
   }
 }
 

--- a/path-manager/app/services/PathStore.scala
+++ b/path-manager/app/services/PathStore.scala
@@ -8,7 +8,7 @@ import scala.collection.JavaConversions._
 import scala.util.matching.Regex
 
 object PathValidator {
-  val validPathRegex = new Regex("^[a-z0-9][a-z0-9-]*(/[a-z0-9-]+)*$")
+  val validPathRegex = new Regex("^[a-z0-9][a-z0-9-]*(/[a-z0-9][a-z0-9-]*)*$")
 
   def isValid(path: String): Boolean = {
     val matches = validPathRegex.pattern.matcher(path).matches()

--- a/path-manager/test/services/PathValidatorTest.scala
+++ b/path-manager/test/services/PathValidatorTest.scala
@@ -8,15 +8,27 @@ class PathValidatorTest extends PlaySpec {
       PathValidator.isValid("path/to/something") must be(true)
       PathValidator.isValid("path/to/something-else") must be(true)
       PathValidator.isValid("global/2018/foo-bar") must be(true)
-      PathValidator.isValid("p/2nfpb") must be(true)
+    }
+
+    "accept a path with a hyphenated starting section" in {
+      PathValidator.isValid("uk-news/2018/feb/07/foo-bar") must be(true)
+    }
+
+    "reject a path when upper cased" in {
+      PathValidator.isValid("PATH/TO/SOMETHING") must be(false)
     }
 
     "reject a path starting with a hyphen" in {
       PathValidator.isValid("-in/valid") must be(false)
+      PathValidator.isValid("-in-valid/path") must be(false)
     }
 
     "reject a path starting with a slash" in {
       PathValidator.isValid("/some/content") must be(false)
+    }
+
+    "reject a path with two adjacent slashes" in {
+      PathValidator.isValid("path//to/something") must be(false)
     }
 
     "reject paths with white space" in {

--- a/path-manager/test/services/PathValidatorTest.scala
+++ b/path-manager/test/services/PathValidatorTest.scala
@@ -44,5 +44,9 @@ class PathValidatorTest extends PlaySpec {
     "reject paths with a combination of single quotes and white space" in {
       PathValidator.isValid("path/to/'something' else-news") must be(false)
     }
+
+    "reject a path with a hyphen after a slash" in {
+      PathValidator.isValid("path/to/-something") must be(false)
+    }
   }
 }


### PR DESCRIPTION
for example, `uk-news` is perfectly valid

also:
- add more tests to cover the whole regex
- log if path fails validation