### PR TITLE
add PathStore integration tests (using DynamoDB docker image)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,10 @@ lazy val dependencies = Seq(
   "org.apache.commons" % "commons-lang3" % "3.11",
   "net.logstash.logback" % "logstash-logback-encoder" % "6.0",
   "com.gu" % "kinesis-logback-appender" % "1.4.4",
-  "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % "test"
+
+  "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % "test",
+  "com.whisk" %% "docker-testkit-scalatest" % "0.9.9" % "test",
+  "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.9" % "test"
 )
 
 lazy val pathManager = project.in(file("path-manager"))

--- a/path-manager/app/services/Dynamo.scala
+++ b/path-manager/app/services/Dynamo.scala
@@ -9,6 +9,8 @@ import play.api.{Logger, Logging}
 
 object Dynamo extends AwsInstanceTags with Logging {
 
+  val LOCAL_PORT = 10005
+
   lazy val stageTablePrefix = readTag("Stage").getOrElse("DEV")
 
   lazy val dynamoDb = new DynamoDB( instanceId match {
@@ -18,7 +20,7 @@ object Dynamo extends AwsInstanceTags with Logging {
     case None => {
       val c = AmazonDynamoDBClientBuilder.standard()
         .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials("local", "local")))
-        .withEndpointConfiguration(new EndpointConfiguration("http://localhost:10005", "local"))
+        .withEndpointConfiguration(new EndpointConfiguration(s"http://localhost:$LOCAL_PORT", "local"))
         .build()
 
       createSequenceTableIfMissing(c)

--- a/path-manager/test/services/DockerDynamoTestBase.scala
+++ b/path-manager/test/services/DockerDynamoTestBase.scala
@@ -1,0 +1,15 @@
+package services
+
+import com.whisk.docker.impl.spotify.DockerKitSpotify
+import com.whisk.docker.scalatest.DockerTestKit
+import com.whisk.docker.{DockerContainer, DockerKit}
+import org.scalatest.TestSuite
+
+trait DockerDynamoTestBase extends TestSuite with DockerKit with DockerTestKit with DockerKitSpotify {
+
+  private val dynamoContainer = DockerContainer("amazon/dynamodb-local")
+    .withPorts(8000-> Some(Dynamo.LOCAL_PORT))
+
+  override def dockerContainers: List[DockerContainer] = dynamoContainer :: super.dockerContainers
+
+}

--- a/path-manager/test/services/PathStoreTest.scala
+++ b/path-manager/test/services/PathStoreTest.scala
@@ -61,6 +61,35 @@ class PathStoreTest extends PlaySpec with DockerDynamoTestBase with BeforeAndAft
 
     }
 
+    "support deleting all path entries" in {
+
+      val pathsForDeletion = PathStore.registerNew(firstPath, system).fold(errorMessage => {
+        fail(s"PathStore.registerNew resulted in a Left($errorMessage)")
+        List()
+      }, _.values.flatten)
+
+      pathsForDeletion.size shouldBe 2 // one canonical and one short
+
+      pathsForDeletion.map(_.path).map(PathStore.getPathDetails).foreach {
+        _ should not be None
+      }
+
+      PathStore.getPathDetails(firstPath).map(_.identifier).fold(
+
+        fail("newly created path not there after supposedly successful creation")
+
+      ){id =>
+
+        PathStore.deleteRecord(id)
+
+        pathsForDeletion.map(_.path).map(PathStore.getPathDetails).foreach(
+          _ shouldBe None
+        )
+
+      }
+
+    }
+
   }
 
 }

--- a/path-manager/test/services/PathStoreTest.scala
+++ b/path-manager/test/services/PathStoreTest.scala
@@ -1,0 +1,66 @@
+package services
+
+import model.PathRecord
+import org.scalatest.matchers.should.Matchers._
+import org.scalatestplus.play._
+import org.scalatest.BeforeAndAfterEach
+
+class PathStoreTest extends PlaySpec with DockerDynamoTestBase with BeforeAndAfterEach {
+
+  val CANONICAL = "canonical"
+
+  val system = "test"
+  val firstPath = "test/first/path"
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    // delete any existing instance of firstPath
+    PathStore.getPathDetails(firstPath).map(_.identifier).foreach(PathStore.deleteRecord)
+  }
+
+  "Path Store" must {
+
+    "support creating a new path entry" in {
+
+      PathStore.registerNew(firstPath, system) shouldBe Symbol("right")
+
+      PathStore.getPathDetails(firstPath).fold(
+        fail("newly created path not there after supposedly successful creation")
+      )(
+        _.path shouldBe firstPath
+      )
+
+    }
+
+    "support updating an existing path entry with a new canonical path" in {
+
+      PathStore.registerNew(firstPath, system) shouldBe Symbol("right")
+
+      val newPath = "test/new/path"
+      PathStore.getPathDetails(newPath).map(_.identifier).foreach(PathStore.deleteRecord)
+
+      val someReservedPath = "test/reserved/path"
+      PathStore.getPathDetails(someReservedPath).map(_.identifier).foreach(PathStore.deleteRecord)
+      PathStore.registerNew(someReservedPath, system) // to simulate existing
+
+      PathStore.getPathDetails(firstPath).map(_.identifier).fold(
+
+        fail("first path wasn't actually created so can't test 'PathStore.updateCanonical'")
+
+      )(id => {
+
+        PathStore.updateCanonical(someReservedPath, id) shouldBe Left("path already in use")
+
+        PathStore.updateCanonical(newPath, id) shouldBe Symbol("right")
+
+        PathStore.getPathDetails(firstPath) shouldBe None
+
+        PathStore.getPathDetails(newPath) shouldBe Some(PathRecord(newPath, id, CANONICAL, system))
+
+      })
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
https://trello.com/c/dGQVgKRl/293-introduce-an-integration-test-harness-for-path-manager-endpoints-prior-to-refactoring
> #### Problem 
> In order to implement the new 'aliasing' feature in PathManager, we must use 'transactions' which weren't available in DynamoDB when Path Manager was first implemented. In https://trello.com/c/GH4sBqFx/290-transactions-in-path-manager we'll be adding support for transactions and refactoring any existing 'transaction-like' logic.
> Right now there are no integration tests at all, so we don't have heaps of confidence for refactoring. 
> 
> #### Solution
> Add integration tests around all 'transaction-like' logic to ensure we have confidence going into refactoring.
> 
> #### Definition of Success
> Passing 🆕 integration tests in CI.

## What does this change?
This PR introduces https://github.com/whisklabs/docker-it-scala into this repo and implemented reusable trait (`DockerDynamoTestBase`) so we can write tests against a local DynamoDB instance.

Using the newly added `DockerDynamoTestBase` added tests for...
- `PathStore.registerNew`
- `PathStore.updateCanonical`
- `PathStore.deleteRecord`

In order for these tests to work in TeamCity the DynamoDB client instantiation had to be updated because it distinguished between connecting to local DynamoDB or a AWS hosted DynamoDB based on whether it was running on an EC2 instance, which since TeamCity agents are EC2 instances the new tests were exploding in CI, so now it checks whether the `Stage` tag is not `DEVINFRA` which means the new tests now run in TeamCity...
![image](https://user-images.githubusercontent.com/19289579/88087743-4b229a00-cb81-11ea-92b3-913e1b6ec942.png)

## How to test
`sbt test`

## How can we measure success?
With these tests in place we have greater confidence going into refactoring these functions to make use of DynamoDB 'transactions'.

## Have we considered potential risks?
These changes just affect local and CI, rather than the running application, so minimal/no increased risk.

## Images
N/A
