### PR TITLE
add/configure 'sbt-docker-compose' to simplify the startup process

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,13 @@ lazy val dependencies = Seq(
   "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.9" % "test"
 )
 
+enablePlugins(DockerCompose)
+
+addCommandAlias("start", "" +
+  "; dockerCompose up -d" +
+  "; compile" +
+  "; pathManager/run")
+
 lazy val pathManager = project.in(file("path-manager"))
   .enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin)
   .settings(Defaults.coreDefaultSettings: _*)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,4 +5,6 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 
+addSbtPlugin("com.github.ehsanyou" % "sbt-docker-compose" % "2.0.0")
+
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))

--- a/readme.md
+++ b/readme.md
@@ -186,19 +186,17 @@ The path manager does not currently support:
 
 Run `setup.sh` to install dependencies, this will also setup dev-nginx mappings.
 
-Run `start.sh` to run the docker container for local DynamoDB and start the project in `sbt`.
+To launch `path-manager` locally, either...
+- `start.sh` to run the docker container for local DynamoDB and start the project in `sbt`
+- OR, within `sbt` you can simply run `start`  (which starts the docker container for local DynamoDB and calls `run` on the `pathManager` sub-project, which starts the Play app). 
+...the path manager should then be accessible on: [https://pathmanager.local.dev-gutools.co.uk/](pathmanager.local.dev-gutools.co.uk/).
+
+Note, the app is configured to run on port 10000.
 
 The local dynamo instance can be deleted with `docker-compose down -v`.
 
 You can access [https://pathmanager-db.local.dev-gutools.co.uk/shell/](pathmanager-db.local.dev-gutools.co.uk/shell/) to query tables etc.
 
-The path manager itself is a play app so can be started by the ```run``` command in the `pathManager` sub project in ```sbt```, the app is configured to run
-on port 10000.
-    
-The path manager should now be accessible on:
-
-   [https://pathmanager.local.dev-gutools.co.uk/](pathmanager.local.dev-gutools.co.uk/)
-   
 
 ## Running a migration
 


### PR DESCRIPTION
_Did this as part of https://trello.com/c/dGQVgKRl/293-introduce-an-integration-test-harness-for-path-manager-endpoints-prior-to-refactoring but not actually necessary for that ticket._

## What does this change?
A relatively small change to essentially move the logic of the `start.sh` script into `sbt start`, using https://github.com/ehsanyou/sbt-docker-compose. This might be against convention so happy to close it if people prefer it in a script, but I felt this was nicer and makes debugging in IntelliJ dead easy.

## How to test
Check out the branch and run `sbt start` you should then be able to use https://pathmanager.local.dev-gutools.co.uk as before.

## How can we measure success?
DevX hopefully improved slightly - might just be me.

## Have we considered potential risks?
This is a local development thing so minimal/no risk.

## Images
N/A