### PR TITLE
.eq seems to be coming from AnyRef and scaring intellij instead of from dynamo

### DIFF
--- a/path-manager/app/services/RangeKeyMatches.java
+++ b/path-manager/app/services/RangeKeyMatches.java
@@ -1,0 +1,9 @@
+package services;
+
+import com.amazonaws.services.dynamodbv2.document.RangeKeyCondition;
+
+public final class RangeKeyMatches {
+    public static final RangeKeyCondition rangeKeyMatches(String attrName, Object val) {
+        return new RangeKeyCondition(attrName).eq(val);
+    }
+}


### PR DESCRIPTION
## What does this change?
Was getting the "red squiggle" from intellij over `new RangeKeyCondition(attrName).eq(val)` where `eq` is defined on `AnyRef` and causing intellij to not lose track of types. This seems to have compiled and compile fine, so I don't know if this is a real problem. But it's much harder to interrogate the code this way. 

This moves the invalid scala to java, where it's happy. 

## How to test
Unsure, this should be a noop. Unless `AnyRef.eq` _was_ getting called and the invalid behavior relied upon. But I doubt this. 

## How can we measure success?
Better code interrogation. 

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
