### PR TITLE
Revert "allow aliases to be handled by path-manager"

### DIFF
--- a/path-manager/app/model/PathRecord.scala
+++ b/path-manager/app/model/PathRecord.scala
@@ -16,8 +16,8 @@ object PathRecord {
 
   def apply(item: Item): PathRecord = PathRecord(
     path = item.getString("path"),
-    identifier = item.getLong("identifier"),
     `type` = item.getString("type"),
+    identifier = item.getLong("identifier"),
     system = item.getString("system")
   )
 }

--- a/path-manager/conf/routes
+++ b/path-manager/conf/routes
@@ -5,7 +5,7 @@ GET     /paths                              controllers.PathManagerController.ge
 
 POST    /paths                              controllers.PathManagerController.registerNewPath
 PUT     /paths/:id                          controllers.PathManagerController.registerExistingPath(id: Long)
-POST    /paths/:id                          controllers.PathManagerController.updateCanonicalPath(id: Long, shouldFormAlias: Boolean)
+POST    /paths/:id                          controllers.PathManagerController.updateCanonicalPath(id: Long)
 DELETE  /paths/:id                          controllers.PathManagerController.deleteRecord(id: Long)
 
 GET     /showCurrentSequence                controllers.PathManagerController.showCurrentSequence

--- a/path-manager/test/services/PathStoreTest.scala
+++ b/path-manager/test/services/PathStoreTest.scala
@@ -8,7 +8,6 @@ import org.scalatest.BeforeAndAfterEach
 class PathStoreTest extends PlaySpec with DockerDynamoTestBase with BeforeAndAfterEach {
 
   val CANONICAL = "canonical"
-  val ALIAS = "alias"
 
   val system = "test"
   val firstPath = "test/first/path"
@@ -61,63 +60,6 @@ class PathStoreTest extends PlaySpec with DockerDynamoTestBase with BeforeAndAft
       })
 
     }
-
-    "support adding an alias to an existing path" in {
-
-      PathStore.registerNew(firstPath, system) shouldBe Symbol("right")
-
-      val newPath = "test/new/path"
-      PathStore.getPathDetails(newPath).map(_.identifier).foreach(PathStore.deleteRecord)
-
-      PathStore.getPathDetails(firstPath).map(_.identifier).fold(
-
-        fail("first path wasn't actually created so can't test 'PathStore.registerAlias'")
-
-      )(id => {
-
-        PathStore.registerAlias(PathRecord(newPath, id, ALIAS, system))
-        
-        val paths = PathStore.getPathsById(id)
-
-        paths.get(ALIAS).flatMap(_.headOption) shouldBe Some(PathRecord(newPath, id, ALIAS, system))
-        
-        paths.get(CANONICAL).flatMap(_.headOption) shouldBe Some(PathRecord(firstPath, id, CANONICAL, system))
-
-      })
-
-    }
-
-
-    "support updating an existing path entry with a new canonical path and adding an alias" in {
-
-      PathStore.registerNew(firstPath, system) shouldBe Symbol("right")
-
-      val newPath = "test/new/path"
-      PathStore.getPathDetails(newPath).map(_.identifier).foreach(PathStore.deleteRecord)
-
-      val someReservedPath = "test/reserved/path"
-      PathStore.getPathDetails(someReservedPath).map(_.identifier).foreach(PathStore.deleteRecord)
-      PathStore.registerNew(someReservedPath, system) // to simulate existing
-
-      PathStore.getPathDetails(firstPath).map(_.identifier).fold(
-
-        fail("first path wasn't actually created so can't test 'PathStore.updateCanonicalWithAlias'")
-
-      )(id => {
-
-        PathStore.updateCanonicalWithAlias(someReservedPath, id) shouldBe Left("path already in use")
-
-        PathStore.updateCanonicalWithAlias(newPath, id) shouldBe Symbol("right")
-
-        PathStore.getPathDetails(firstPath) shouldBe Some(PathRecord(firstPath, id, ALIAS, system))
-
-        PathStore.getPathDetails(newPath) shouldBe Some(PathRecord(newPath, id, CANONICAL, system))
-        
-
-      })
-
-    }
-
 
     "support deleting all path entries" in {
 

--- a/path-manager/test/services/PathValidatorTest.scala
+++ b/path-manager/test/services/PathValidatorTest.scala
@@ -5,63 +5,48 @@ import org.scalatestplus.play._
 class PathValidatorTest extends PlaySpec {
   "Path Validator" must {
     "accept hyphenated alphanumeric paths" in {
-      PathValidator.isValid("path/to/something") must be (true) 
-      PathValidator.isInvalid("path/to/something") must be (false)
-      PathValidator.isValid("path/to/something-else") must be (true) 
-      PathValidator.isInvalid("path/to/something-else") must be (false)
-      PathValidator.isValid("global/2018/foo-bar") must be (true) 
-      PathValidator.isInvalid("global/2018/foo-bar") must be (false)
+      PathValidator.isValid("path/to/something") must be(true)
+      PathValidator.isValid("path/to/something-else") must be(true)
+      PathValidator.isValid("global/2018/foo-bar") must be(true)
     }
 
     "accept a path with a hyphenated starting section" in {
-      PathValidator.isValid("uk-news/2018/feb/07/foo-bar") must be (true) 
-      PathValidator.isInvalid("uk-news/2018/feb/07/foo-bar") must be (false)
+      PathValidator.isValid("uk-news/2018/feb/07/foo-bar") must be(true)
     }
 
     "reject a path when upper cased" in {
-      PathValidator.isValid("PATH/TO/SOMETHING") must be (false) 
-      PathValidator.isInvalid("PATH/TO/SOMETHING") must be (true)
+      PathValidator.isValid("PATH/TO/SOMETHING") must be(false)
     }
 
     "reject a path starting with a hyphen" in {
-      PathValidator.isValid("-in/valid") must be (false) 
-      PathValidator.isInvalid("-in/valid") must be (true)
-      PathValidator.isValid("-in-valid/path") must be (false) 
-      PathValidator.isInvalid("-in-valid/path") must be (true)
+      PathValidator.isValid("-in/valid") must be(false)
+      PathValidator.isValid("-in-valid/path") must be(false)
     }
 
     "reject a path starting with a slash" in {
-      PathValidator.isValid("/some/content") must be (false) 
-      PathValidator.isInvalid("/some/content") must be (true)
+      PathValidator.isValid("/some/content") must be(false)
     }
 
     "reject a path with two adjacent slashes" in {
-      PathValidator.isValid("path//to/something") must be (false) 
-      PathValidator.isInvalid("path//to/something") must be (true)
+      PathValidator.isValid("path//to/something") must be(false)
     }
 
     "reject paths with white space" in {
-      PathValidator.isValid("path/to/some thing") must be (false) 
-      PathValidator.isInvalid("path/to/some thing") must be (true)
-      PathValidator.isValid("path/to/some thing else") must be (false) 
-      PathValidator.isInvalid("path/to/some thing else") must be (true)
+      PathValidator.isValid("path/to/some thing") must be(false)
+      PathValidator.isValid("path/to/some thing else") must be(false)
     }
 
     "reject paths with single quotes" in {
-      PathValidator.isValid("path/to/'something'") must be (false) 
-      PathValidator.isInvalid("path/to/'something'") must be (true)
-      PathValidator.isValid("path/to/'something'-else") must be (false) 
-      PathValidator.isInvalid("path/to/'something'-else") must be (true)
+      PathValidator.isValid("path/to/'something'") must be(false)
+      PathValidator.isValid("path/to/'something'-else") must be(false)
     }
 
     "reject paths with a combination of single quotes and white space" in {
-      PathValidator.isValid("path/to/'something' else-news") must be (false) 
-      PathValidator.isInvalid("path/to/'something' else-news") must be (true)
+      PathValidator.isValid("path/to/'something' else-news") must be(false)
     }
 
     "reject a path with a hyphen after a slash" in {
-      PathValidator.isValid("path/to/-something") must be (false) 
-      PathValidator.isInvalid("path/to/-something") must be (true)
+      PathValidator.isValid("path/to/-something") must be(false)
     }
   }
 }


### PR DESCRIPTION
Reverts guardian/path-manager#33

This has a mandatory new URL param on the POST route, which isn't currently sent by composer. This would have broken on PROD, however the upgrades in #32 started producing a differently named deb, and so prod is still running with pre-#32 application. 

Going to revert this, fix deployment and then fix this.