### PR TITLE
Revert "Revert "allow aliases to be handled by path-manager""

### DIFF
--- a/path-manager/app/controllers/PathManagerController.scala
+++ b/path-manager/app/controllers/PathManagerController.scala
@@ -29,17 +29,15 @@ class PathManagerController(override val controllerComponents: ControllerCompone
   }
 
   def registerExistingPath(id: Long) = Action { request =>
-    request.body.asJson.map(_.as[PathRecord]).map { submission =>
-      if (id != submission.identifier) {
+    request.body.asJson.map(_.as[PathRecord]) match {
+      case (Some(path)) if path.identifier != id => {
         PathOperationErrors.increment
         logger.warn("registerExistingPath failed, identifier in url and body do not match")
         BadRequest("identifier in url and body do not match")
-      } else if (submission.`type` != "canonical") {
-        PathOperationErrors.increment
-        logger.warn("registerExistingPath failed, only canonical paths can be updated at present")
-        BadRequest("only canonical paths can be updated at present")
-      } else {
-        PathStore.register(submission) match {
+      }
+
+      case Some(path) if path.`type` == "alias" => {
+        PathStore.registerAlias(path) match {
           case Left(error) => BadRequest(error)
           case Right(records) => {
             PathMigrationRegistrations.increment
@@ -47,19 +45,37 @@ class PathManagerController(override val controllerComponents: ControllerCompone
           }
         }
       }
-    } getOrElse{
-      PathOperationErrors.increment
-      logger.warn("registerExistingPath failed, unable to parse PathRecord from request body")
-      BadRequest("unable to parse PathRecord from request body")
+      case Some(path) if path.`type` == "canonical"  => {
+        PathStore.registerCanonical(path) match {
+          case Left(error) => BadRequest(error)
+          case Right(records) => {
+            PathMigrationRegistrations.increment
+            argoOk(Json.toJson(records))
+          }
+        }
+      }
+      case Some(_)  => {
+        PathOperationErrors.increment
+        logger.warn("registerExistingPath failed, only canonical and alias paths can be updated at present")
+        BadRequest("only canonical paths can be updated at present")
+      }
+      case None => {
+        PathOperationErrors.increment
+        logger.warn("registerExistingPath failed, unable to parse PathRecord from request body")
+        BadRequest("unable to parse PathRecord from request body")
+      }
+
     }
+
   }
 
-  def updateCanonicalPath(id: Long) = Action { request =>
-
+  def updateCanonicalPath(id: Long, shouldFormAlias: Boolean) = Action { request =>
     val submission = request.body.asFormUrlEncoded.get
     val newPath = submission("path").head
 
-    PathStore.updateCanonical(newPath, id) match {
+    val update = if (shouldFormAlias) {PathStore.updateCanonicalWithAlias _} else {PathStore.updateCanonical _}
+
+    update(newPath,id) match {
       case Left(error) => {
         PathOperationErrors.increment
         BadRequest(error)

--- a/path-manager/app/controllers/PathManagerController.scala
+++ b/path-manager/app/controllers/PathManagerController.scala
@@ -69,11 +69,11 @@ class PathManagerController(override val controllerComponents: ControllerCompone
 
   }
 
-  def updateCanonicalPath(id: Long, shouldFormAlias: Boolean) = Action { request =>
+  def updateCanonicalPath(id: Long, shouldFormAlias: Option[Boolean]) = Action { request =>
     val submission = request.body.asFormUrlEncoded.get
     val newPath = submission("path").head
 
-    val update = if (shouldFormAlias) {PathStore.updateCanonicalWithAlias _} else {PathStore.updateCanonical _}
+    val update = if (shouldFormAlias.contains(true)) {PathStore.updateCanonicalWithAlias _} else {PathStore.updateCanonical _}
 
     update(newPath,id) match {
       case Left(error) => {

--- a/path-manager/app/model/PathRecord.scala
+++ b/path-manager/app/model/PathRecord.scala
@@ -16,8 +16,8 @@ object PathRecord {
 
   def apply(item: Item): PathRecord = PathRecord(
     path = item.getString("path"),
-    `type` = item.getString("type"),
     identifier = item.getLong("identifier"),
+    `type` = item.getString("type"),
     system = item.getString("system")
   )
 }

--- a/path-manager/app/services/PathStore.scala
+++ b/path-manager/app/services/PathStore.scala
@@ -1,6 +1,6 @@
 package services
 
-import com.amazonaws.services.dynamodbv2.document.{Index, KeyAttribute, RangeKeyCondition}
+import com.amazonaws.services.dynamodbv2.document.{AttributeUpdate, Index, KeyAttribute, RangeKeyCondition}
 import model.PathRecord
 import play.api.Logging
 
@@ -15,6 +15,7 @@ object PathValidator extends Logging {
     if (!matches) logger.warn(s"path fails validation [$path]")
     matches
   }
+  def isInvalid(path: String):Boolean = !isValid(path)
 }
 
 object PathStore extends Logging {
@@ -23,7 +24,7 @@ object PathStore extends Logging {
 
     logger.debug(s"Registering new path [$path]")
 
-    if (!PathValidator.isValid(path)) {
+    if (PathValidator.isInvalid(path)) {
       Left(s"invalid path [$path]")
     } else {
       val existingPath = Option(Dynamo.pathsTable.getItem("path", path)).map(PathRecord(_))
@@ -50,13 +51,13 @@ object PathStore extends Logging {
     }
   }
 
-  def register(proposedPathRecord: PathRecord) = {
+  def registerCanonical(proposedPathRecord: PathRecord) = {
 
     val id = proposedPathRecord.identifier
 
     logger.debug(s"Registering path [${proposedPathRecord.path }] for [$id]")
 
-    if (!PathValidator.isValid(proposedPathRecord.path)) {
+    if (PathValidator.isInvalid(proposedPathRecord.path)) {
       Left(s"invalid path [${proposedPathRecord.path}]")
     } else {
       val existingPath = Option(Dynamo.pathsTable.getItem("path", proposedPathRecord.path)).map(PathRecord(_))
@@ -96,11 +97,76 @@ object PathStore extends Logging {
     }
   }
 
-  def updateCanonical(newPath: String, id: Long) = {
+  def registerAlias(proposedAliasPathRecord: PathRecord) = {
+
+    val id = proposedAliasPathRecord.identifier
+
+    logger.debug(s"Registering path [${proposedAliasPathRecord.path }] for [$id]")
+
+    if (PathValidator.isInvalid(proposedAliasPathRecord.path)) {
+      Left(s"invalid path [${proposedAliasPathRecord.path}]")
+    } else {
+      val existingPath = Option(Dynamo.pathsTable.getItem("path", proposedAliasPathRecord.path)).map(PathRecord(_))
+
+      existingPath match {
+        case Some(pr) if (pr.identifier != id) => {
+          logger.warn(s"Failed to register existing path [${proposedAliasPathRecord.path}], already claimed by id [${pr.identifier}], submitting id [$id]")
+          Left("path already in use")
+        }
+        case _ => {
+          putPathItemAndAwaitIndexUpdate(proposedAliasPathRecord)
+
+          logger.debug(s"Registered new alias path [${proposedAliasPathRecord.path}] for id [$id] successfully")
+          Right(List(proposedAliasPathRecord).groupBy(_.`type`))
+        }
+      }
+    }
+  }
+
+  def updateCanonicalWithAlias(newPath: String, id: Long): Either[String, Map[String, List[PathRecord]]] = {
+    //This takes the canonical path and makes it an alias. And then adds a new canonical path for newPath.
+    
+    logger.debug(s"Updating canonical path [$newPath}] for [$id] and creating alias to old path.")
+
+    if (PathValidator.isInvalid(newPath)) {
+      Left(s"invalid path [$newPath]")
+    } else {
+      val newPathRecord = Option(Dynamo.pathsTable.getItem("path", newPath)).map(PathRecord(_))
+      val pathsForId = Dynamo.pathsTable.getIndex("id-index").query(new KeyAttribute("identifier", id)).asScala
+      val canonicalPathForId = pathsForId.map{ PathRecord(_) }.find(_.`type`=="canonical")
+
+      if(newPathRecord.exists(_.identifier != id)) {
+        logger.warn(s"Failed to update path [$newPath], already claimed by id [${newPathRecord.map{_.identifier}.get}], submitting id [$id]")
+        Left("path already in use")
+      } else {
+        canonicalPathForId.map { existingRecord: PathRecord =>
+
+          val existingPath = existingRecord.path
+          val updatedRecord = if (existingPath != newPath) {
+            val newRecord = existingRecord.copy(path = newPath)
+            val aliasRecord = existingRecord.copy(`type` = "alias")
+            logger.debug(s"Aliasing old path for item [$id]. old path[$existingPath] new path [$newPath]")
+            Dynamo.pathsTable.updateItem("path", existingPath, new AttributeUpdate("type").put("alias"))
+            putPathItemAndAwaitIndexUpdate(newRecord)
+            newRecord
+          } else {
+            existingRecord
+          }
+          logger.debug(s"updated canonical path [$newPath}] and added alias to [$existingPath] id [$id] successfully")
+          List(updatedRecord).groupBy(_.`type`)
+        }.toRight{
+          logger.warn(s"Failed to update path [$newPath], no existing path found for id [$id]")
+          s"unable to find canonical record for $id"
+        }
+      }
+    }
+  }
+
+  def updateCanonical(newPath: String, id: Long): Either[String, Map[String, List[PathRecord]]] = {
 
     logger.debug(s"Updating canonical path [$newPath}] for [$id]")
 
-    if (!PathValidator.isValid(newPath)) {
+    if (PathValidator.isInvalid(newPath)) {
       Left(s"invalid path [$newPath]")
     } else {
       val newPathRecord = Option(Dynamo.pathsTable.getItem("path", newPath)).map(PathRecord(_))

--- a/path-manager/conf/routes
+++ b/path-manager/conf/routes
@@ -5,7 +5,7 @@ GET     /paths                              controllers.PathManagerController.ge
 
 POST    /paths                              controllers.PathManagerController.registerNewPath
 PUT     /paths/:id                          controllers.PathManagerController.registerExistingPath(id: Long)
-POST    /paths/:id                          controllers.PathManagerController.updateCanonicalPath(id: Long, shouldFormAlias: Boolean)
+POST    /paths/:id                          controllers.PathManagerController.updateCanonicalPath(id: Long, shouldFormAlias: Option[Boolean])
 DELETE  /paths/:id                          controllers.PathManagerController.deleteRecord(id: Long)
 
 GET     /showCurrentSequence                controllers.PathManagerController.showCurrentSequence

--- a/path-manager/conf/routes
+++ b/path-manager/conf/routes
@@ -5,7 +5,7 @@ GET     /paths                              controllers.PathManagerController.ge
 
 POST    /paths                              controllers.PathManagerController.registerNewPath
 PUT     /paths/:id                          controllers.PathManagerController.registerExistingPath(id: Long)
-POST    /paths/:id                          controllers.PathManagerController.updateCanonicalPath(id: Long)
+POST    /paths/:id                          controllers.PathManagerController.updateCanonicalPath(id: Long, shouldFormAlias: Boolean)
 DELETE  /paths/:id                          controllers.PathManagerController.deleteRecord(id: Long)
 
 GET     /showCurrentSequence                controllers.PathManagerController.showCurrentSequence

--- a/path-manager/test/services/PathStoreTest.scala
+++ b/path-manager/test/services/PathStoreTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.BeforeAndAfterEach
 class PathStoreTest extends PlaySpec with DockerDynamoTestBase with BeforeAndAfterEach {
 
   val CANONICAL = "canonical"
+  val ALIAS = "alias"
 
   val system = "test"
   val firstPath = "test/first/path"
@@ -60,6 +61,63 @@ class PathStoreTest extends PlaySpec with DockerDynamoTestBase with BeforeAndAft
       })
 
     }
+
+    "support adding an alias to an existing path" in {
+
+      PathStore.registerNew(firstPath, system) shouldBe Symbol("right")
+
+      val newPath = "test/new/path"
+      PathStore.getPathDetails(newPath).map(_.identifier).foreach(PathStore.deleteRecord)
+
+      PathStore.getPathDetails(firstPath).map(_.identifier).fold(
+
+        fail("first path wasn't actually created so can't test 'PathStore.registerAlias'")
+
+      )(id => {
+
+        PathStore.registerAlias(PathRecord(newPath, id, ALIAS, system))
+        
+        val paths = PathStore.getPathsById(id)
+
+        paths.get(ALIAS).flatMap(_.headOption) shouldBe Some(PathRecord(newPath, id, ALIAS, system))
+        
+        paths.get(CANONICAL).flatMap(_.headOption) shouldBe Some(PathRecord(firstPath, id, CANONICAL, system))
+
+      })
+
+    }
+
+
+    "support updating an existing path entry with a new canonical path and adding an alias" in {
+
+      PathStore.registerNew(firstPath, system) shouldBe Symbol("right")
+
+      val newPath = "test/new/path"
+      PathStore.getPathDetails(newPath).map(_.identifier).foreach(PathStore.deleteRecord)
+
+      val someReservedPath = "test/reserved/path"
+      PathStore.getPathDetails(someReservedPath).map(_.identifier).foreach(PathStore.deleteRecord)
+      PathStore.registerNew(someReservedPath, system) // to simulate existing
+
+      PathStore.getPathDetails(firstPath).map(_.identifier).fold(
+
+        fail("first path wasn't actually created so can't test 'PathStore.updateCanonicalWithAlias'")
+
+      )(id => {
+
+        PathStore.updateCanonicalWithAlias(someReservedPath, id) shouldBe Left("path already in use")
+
+        PathStore.updateCanonicalWithAlias(newPath, id) shouldBe Symbol("right")
+
+        PathStore.getPathDetails(firstPath) shouldBe Some(PathRecord(firstPath, id, ALIAS, system))
+
+        PathStore.getPathDetails(newPath) shouldBe Some(PathRecord(newPath, id, CANONICAL, system))
+        
+
+      })
+
+    }
+
 
     "support deleting all path entries" in {
 

--- a/path-manager/test/services/PathValidatorTest.scala
+++ b/path-manager/test/services/PathValidatorTest.scala
@@ -5,48 +5,63 @@ import org.scalatestplus.play._
 class PathValidatorTest extends PlaySpec {
   "Path Validator" must {
     "accept hyphenated alphanumeric paths" in {
-      PathValidator.isValid("path/to/something") must be(true)
-      PathValidator.isValid("path/to/something-else") must be(true)
-      PathValidator.isValid("global/2018/foo-bar") must be(true)
+      PathValidator.isValid("path/to/something") must be (true) 
+      PathValidator.isInvalid("path/to/something") must be (false)
+      PathValidator.isValid("path/to/something-else") must be (true) 
+      PathValidator.isInvalid("path/to/something-else") must be (false)
+      PathValidator.isValid("global/2018/foo-bar") must be (true) 
+      PathValidator.isInvalid("global/2018/foo-bar") must be (false)
     }
 
     "accept a path with a hyphenated starting section" in {
-      PathValidator.isValid("uk-news/2018/feb/07/foo-bar") must be(true)
+      PathValidator.isValid("uk-news/2018/feb/07/foo-bar") must be (true) 
+      PathValidator.isInvalid("uk-news/2018/feb/07/foo-bar") must be (false)
     }
 
     "reject a path when upper cased" in {
-      PathValidator.isValid("PATH/TO/SOMETHING") must be(false)
+      PathValidator.isValid("PATH/TO/SOMETHING") must be (false) 
+      PathValidator.isInvalid("PATH/TO/SOMETHING") must be (true)
     }
 
     "reject a path starting with a hyphen" in {
-      PathValidator.isValid("-in/valid") must be(false)
-      PathValidator.isValid("-in-valid/path") must be(false)
+      PathValidator.isValid("-in/valid") must be (false) 
+      PathValidator.isInvalid("-in/valid") must be (true)
+      PathValidator.isValid("-in-valid/path") must be (false) 
+      PathValidator.isInvalid("-in-valid/path") must be (true)
     }
 
     "reject a path starting with a slash" in {
-      PathValidator.isValid("/some/content") must be(false)
+      PathValidator.isValid("/some/content") must be (false) 
+      PathValidator.isInvalid("/some/content") must be (true)
     }
 
     "reject a path with two adjacent slashes" in {
-      PathValidator.isValid("path//to/something") must be(false)
+      PathValidator.isValid("path//to/something") must be (false) 
+      PathValidator.isInvalid("path//to/something") must be (true)
     }
 
     "reject paths with white space" in {
-      PathValidator.isValid("path/to/some thing") must be(false)
-      PathValidator.isValid("path/to/some thing else") must be(false)
+      PathValidator.isValid("path/to/some thing") must be (false) 
+      PathValidator.isInvalid("path/to/some thing") must be (true)
+      PathValidator.isValid("path/to/some thing else") must be (false) 
+      PathValidator.isInvalid("path/to/some thing else") must be (true)
     }
 
     "reject paths with single quotes" in {
-      PathValidator.isValid("path/to/'something'") must be(false)
-      PathValidator.isValid("path/to/'something'-else") must be(false)
+      PathValidator.isValid("path/to/'something'") must be (false) 
+      PathValidator.isInvalid("path/to/'something'") must be (true)
+      PathValidator.isValid("path/to/'something'-else") must be (false) 
+      PathValidator.isInvalid("path/to/'something'-else") must be (true)
     }
 
     "reject paths with a combination of single quotes and white space" in {
-      PathValidator.isValid("path/to/'something' else-news") must be(false)
+      PathValidator.isValid("path/to/'something' else-news") must be (false) 
+      PathValidator.isInvalid("path/to/'something' else-news") must be (true)
     }
 
     "reject a path with a hyphen after a slash" in {
-      PathValidator.isValid("path/to/-something") must be(false)
+      PathValidator.isValid("path/to/-something") must be (false) 
+      PathValidator.isInvalid("path/to/-something") must be (true)
     }
   }
 }


### PR DESCRIPTION
This PR effectively reinstates #33 **but IMPORTANTLY makes the new `shouldFormAlias` URL param optional** (as it being mandatory would have caused errors with current composer integration if it wasn't for the fact that since #32 we'd actually just been deploying old artifacts, this is now resoved btw - see https://trello.com/c/22AgjZkF/397-resolve-missed-deployments-of-path-manager).