### PR TITLE
return all the alias paths when `updateCanonicalWithAlias` (with a `lastModified`)

### DIFF
--- a/path-manager/app/controllers/PathManagerController.scala
+++ b/path-manager/app/controllers/PathManagerController.scala
@@ -80,9 +80,9 @@ class PathManagerController(override val controllerComponents: ControllerCompone
         PathOperationErrors.increment
         BadRequest(error)
       }
-      case Right(record) => {
+      case Right(result) => {
         PathUpdates.increment
-        Ok(Json.toJson(record))
+        Ok(Json.toJson(result))
       }
     }
   }

--- a/path-manager/app/model/PathRecord.scala
+++ b/path-manager/app/model/PathRecord.scala
@@ -10,7 +10,8 @@ object PathRecord {
     (JsPath \ "path").format[String] and
       (JsPath \ "identifier").format[Long] and
       (JsPath \ "type").format[String] and
-      (JsPath \ "system").format[String]
+      (JsPath \ "system").format[String] and
+      (JsPath \ "lastModified").formatNullable[Long]
     )(PathRecord.apply, unlift(PathRecord.unapply))
 
 
@@ -18,15 +19,25 @@ object PathRecord {
     path = item.getString("path"),
     identifier = item.getLong("identifier"),
     `type` = item.getString("type"),
-    system = item.getString("system")
+    system = item.getString("system"),
+    lastModified = if(item.hasAttribute("lastModified")) Some(item.getLong("lastModified")) else None
   )
 }
 
-case class PathRecord(path: String, identifier: Long, `type`: String, system: String) {
+case class PathRecord(path: String, identifier: Long, `type`: String, system: String, lastModified: Option[Long] = None) {
 
-  def asDynamoItem = new Item()
-    .withString("path", path)
-    .withLong("identifier", identifier)
-    .withString("type", `type`)
-    .withString("system", system)
+  def asDynamoItem = {
+    val item = new Item()
+      .withString("path", path)
+      .withLong("identifier", identifier)
+      .withString("type", `type`)
+      .withString("system", system)
+
+    lastModified.fold(
+      item
+    )(
+      item.withLong("lastModified", _)
+    )
+  }
+
 }

--- a/path-manager/app/services/Dynamo.scala
+++ b/path-manager/app/services/Dynamo.scala
@@ -14,7 +14,7 @@ object Dynamo extends AwsInstanceTags with Logging {
   lazy val stage: String = readTag("Stage").getOrElse("DEV")
 
   lazy val dynamoDb = new DynamoDB( instanceId match {
-    case Some(_) if stage != "DEVINFRA" =>
+    case Some(_) if readTag("App").contains("path-manager" /* therefore excludes TeamCity*/) =>
       AmazonDynamoDBClientBuilder.standard().withRegion(AWS.region).build()
 
     case _ => {

--- a/path-manager/test/services/PathStoreTest.scala
+++ b/path-manager/test/services/PathStoreTest.scala
@@ -109,7 +109,19 @@ class PathStoreTest extends PlaySpec with DockerDynamoTestBase with BeforeAndAft
 
         PathStore.updateCanonicalWithAlias(newPath, id) shouldBe Symbol("right")
 
-        PathStore.getPathDetails(firstPath) shouldBe Some(PathRecord(firstPath, id, ALIAS, system))
+        PathStore.getPathDetails(firstPath).fold(
+
+          fail("first path couldn't be found after re-looking it up")
+
+        ) { pathRecord =>
+
+          pathRecord.path shouldBe firstPath
+          pathRecord.identifier shouldBe id
+          pathRecord.`type` shouldBe ALIAS
+          pathRecord.system shouldBe system
+          withClue("alias records should have a lastModified"){ pathRecord.lastModified.isDefined shouldBe true }
+
+        }
 
         PathStore.getPathDetails(newPath) shouldBe Some(PathRecord(newPath, id, CANONICAL, system))
         


### PR DESCRIPTION
## What does this change?
- refactor `"canonical"` and `"alias"` path types into constants (`CANONICAL_PATH_TYPE` and `ALIAS_PATH_TYPE` respectively) to avoid repetition
- return all the alias paths along with the canonical on `updateCanonicalWithAlias` - **so we can keep _composer_ up to date with the source of truth**
- add a `lastModified` property to all the alias path records - so we can sort them in _composer_ (dynamodb does not retain insertion order)
- in order to do the two above, I had to change the`Dynamo.pathsTable.updateItem` call to have a 'return value' mode of `ALL_NEW` so we could get the item representing the _'new'_ alias record (so it can be returned with the 'new' canonical and any previous alias records).

PLUS it looks like the `Stage` of TeamCity has changed to something other than `DEVINFRA` and as such TC agent was attempting to connect to Dynamo in AWS (rather than the local one launched via DockerKit) - so changed this initialisation to rely on the `App` tag being `path-manager` (which we control and so less likely to break without us realising).

## How to test (with postman or similar)

1. run `path-manager` locally (easiest way is `sbt start`)
2. `POST` `https://pathmanager.local.dev-gutools.co.uk/paths`
   - `Content-Type`: `application/x-www-form-urlencoded`
   - with a `path` property set to something of your choice (e.g. `pr/testing/1` )
   - with a `system` property set to something like `test`
3. `POST` `https://pathmanager.local.dev-gutools.co.uk/paths/{ ID_FROM_STEP_2 }?shouldFormAlias=true`
   - with `{ ID_FROM_STEP_2 }` replaced accordingly
   - `Content-Type`: `application/x-www-form-urlencoded`
   - with a `path` property set to something of your choice (e.g. `pr/testing/2`, i.e different from step 2 )
4. repeat step 3 with a another `path`
5. Observe the response...
   - your path from step 4, should be in the `canonical` record
   - your paths from step 2 & 3 should be `alias` records
   - each `alias` record should have a `lastModified` property
 
## How can we measure success?
This is a facilitates a composer PR which integrates the alias functionality in `path-manager` for use in the Evolving URLs project - https://github.com/guardian/flexible-content/pull/3620.

## Have we considered potential risks?
Main risk would be performance, if this is used for articles which have a large amount of aliases, but I suggest we cross that bridge at the time if it actually causes problems.