### PR TITLE
new `isRemoved` flag and endpoint

### DIFF
--- a/path-manager/app/model/PathRecord.scala
+++ b/path-manager/app/model/PathRecord.scala
@@ -11,7 +11,8 @@ object PathRecord {
       (JsPath \ "identifier").format[Long] and
       (JsPath \ "type").format[String] and
       (JsPath \ "system").format[String] and
-      (JsPath \ "lastModified").formatNullable[Long]
+      (JsPath \ "lastModified").formatNullable[Long] and
+      (JsPath \ "isRemoved").formatNullable[Boolean]
     )(PathRecord.apply, unlift(PathRecord.unapply))
 
 
@@ -20,23 +21,37 @@ object PathRecord {
     identifier = item.getLong("identifier"),
     `type` = item.getString("type"),
     system = item.getString("system"),
-    lastModified = if(item.hasAttribute("lastModified")) Some(item.getLong("lastModified")) else None
+    lastModified = if(item.hasAttribute("lastModified")) Some(item.getLong("lastModified")) else None,
+    isRemoved = if(item.hasAttribute("isRemoved")) Some(item.getBoolean("isRemoved")) else None
   )
 }
 
-case class PathRecord(path: String, identifier: Long, `type`: String, system: String, lastModified: Option[Long] = None) {
+case class PathRecord(
+  path: String,
+  identifier: Long,
+  `type`: String,
+  system: String,
+  lastModified: Option[Long] = None,
+  isRemoved: Option[Boolean] = None
+) {
 
   def asDynamoItem = {
-    val item = new Item()
+    val baseItem = new Item()
       .withString("path", path)
       .withLong("identifier", identifier)
       .withString("type", `type`)
       .withString("system", system)
 
-    lastModified.fold(
-      item
+    val intermediateItem = lastModified.fold(
+      baseItem
     )(
-      item.withLong("lastModified", _)
+      baseItem.withLong("lastModified", _)
+    )
+
+    isRemoved.fold(
+      intermediateItem
+    )(
+      intermediateItem.withBoolean("isRemoved", _)
     )
   }
 

--- a/path-manager/conf/routes
+++ b/path-manager/conf/routes
@@ -4,6 +4,7 @@ GET     /paths/:id                          controllers.PathManagerController.ge
 GET     /paths                              controllers.PathManagerController.getPathDetails(path: String)
 
 POST    /paths                              controllers.PathManagerController.registerNewPath
+POST    /paths/aliasPathIsRemoved           controllers.PathManagerController.setAliasPathIsRemovedFlag(path: String)
 PUT     /paths/:id                          controllers.PathManagerController.registerExistingPath(id: Long)
 POST    /paths/:id                          controllers.PathManagerController.updateCanonicalPath(id: Long, shouldFormAlias: Option[Boolean])
 DELETE  /paths/:id                          controllers.PathManagerController.deleteRecord(id: Long)


### PR DESCRIPTION
https://trello.com/c/eRxPU16A/451-support-deleting-alias-paths

In the 'legal' use cases of the Evolving URLs functionality, there are scenarios where we need to remove any **public-facing** trace of a URL (e.g. some contentious headline, that the original URL was formed from).

However we need to ensure that path can never be taken again, so we effectively need to **flag** it as deleted in `path-manager`, change the data-structure in composer to support this concept too, then filter out *deleted* aliasPaths in the `aliasPaths` list which goes off to CAPI (see https://github.com/guardian/flexible-content/pull/3641).

## What does this change?

- Adds an optional `isRemoved` flag to path records (optional so as not to pollute/confuse other records)
- Adds a new `POST` endpoint `/paths/aliasPathIsRemoved` which takes a `path` query parameter and a body of `true` or `false` (the latter allowing for an alias path to restored if accidentally 'deleted') which sets the above flag on the specified alias path record and returns the full list of aliases (so the `composer` can overwrite its list of `aliasPaths` with the latest - see https://github.com/guardian/flexible-content/pull/3641).

## How to test
Easiest way to test is probably via the testing instructions in https://github.com/guardian/flexible-content/pull/3641 (as composer essentially proxies this new functionality).

To test the new functionality directly, checkout this branch and launch using `sbt start` then using Postman make a `POST` to `https://pathmanager.local.dev-gutools.co.uk/paths?path=ALIAS_PATH` (where `ALIAS_PATH` is a valid alias path already in path-manager - see https://github.com/guardian/path-manager/pull/33 for how to convert canonicals to alias paths) you should get back a full list of alias paths with the `isRemoved` property of the path you used for `ALIAS_PATH` marked accordingly.

## How can we measure success?
Users with the 'Evolving URLs' permission in composer will be able to 'delete' previous URLs in legal scenarios (and then restore if 'deleted' by mistake).