### PR TITLE
remove reference to 'master' from the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -200,7 +200,7 @@ You can access [https://pathmanager-db.local.dev-gutools.co.uk/shell/](pathmanag
 
 ## Running a migration
 
-Please see [https://github.com/guardian/path-manager/blob/master/migrator/readme.md](migrator/readme.md).
+Please see [/migrator/readme.md](migrator/readme.md).
 
 ## Refreshing from PROD
 


### PR DESCRIPTION
Addresses https://github.com/guardian/path-manager/issues/41 (following another successful use of the wonderful https://github.com/guardian/master-to-main)