### PR TITLE
rework alias path removal into DELETE & POST endpoints

### DIFF
--- a/path-manager/app/controllers/PathManagerController.scala
+++ b/path-manager/app/controllers/PathManagerController.scala
@@ -89,8 +89,9 @@ class PathManagerController(override val controllerComponents: ControllerCompone
     }
   }
 
-  def setAliasPathIsRemovedFlag(path: String) = Action { request =>
-    val isRemoved = request.body.asJson.get.as[Boolean]
+  def markAliasPathAsRemoved = setAliasPathIsRemovedFlag(true) _
+  def restoreRemovedAliasPath = setAliasPathIsRemovedFlag(false) _
+  private def setAliasPathIsRemovedFlag(isRemoved: Boolean)(path: String)  = Action { request =>
 
     PathStore.setAliasPathIsRemovedFlag(path, isRemoved).fold {
       PathOperationErrors.increment

--- a/path-manager/conf/routes
+++ b/path-manager/conf/routes
@@ -3,8 +3,10 @@
 GET     /paths/:id                          controllers.PathManagerController.getPathsById(id: Long)
 GET     /paths                              controllers.PathManagerController.getPathDetails(path: String)
 
+POST    /aliasPath                          controllers.PathManagerController.restoreRemovedAliasPath(path: String)
+DELETE  /aliasPath                          controllers.PathManagerController.markAliasPathAsRemoved(path: String)
+
 POST    /paths                              controllers.PathManagerController.registerNewPath
-POST    /paths/aliasPathIsRemoved           controllers.PathManagerController.setAliasPathIsRemovedFlag(path: String)
 PUT     /paths/:id                          controllers.PathManagerController.registerExistingPath(id: Long)
 POST    /paths/:id                          controllers.PathManagerController.updateCanonicalPath(id: Long, shouldFormAlias: Option[Boolean])
 DELETE  /paths/:id                          controllers.PathManagerController.deleteRecord(id: Long)


### PR DESCRIPTION
https://github.com/guardian/path-manager/pull/39 introduced the concept of the `isRemoved` flag on alias paths along with a single `POST` `/paths/aliasPathIsRemoved ` endpoint for modifying this, which I've never been particularly comfortable with.

## What does this change?
This PR refactors that into a more nicely named **`/aliasPath?path=ALIAS_PATH`** endpoint which supports...
- **`DELETE`** to mark the supplied `ALIAS_PATH` as removed
- **`POST`** to 'restore' the supplied `ALIAS_PATH` that was previously marked as removed

... neither take a body, and both return the updated list of alias `PathRecord`s. 

_Note I had hoped to do this with a `PATCH` endpoint (which would be the most 'RESTful' way), however this was not possible, see https://github.com/guardian/path-manager/pull/44#issuecomment-717297830._

## How to test
Unless you have `path-manager` set-up locally with some alias paths (in which case it's self explanatory to test, then it's easiest to test in CODE via the testing instructions in https://github.com/guardian/flexible-content/pull/3685 (which is the refactor PR to mirror this PR).

## How can we measure success?
No notable 'success' to speak of, more just clean-up of some sub-optimal naming and API structure.

## Have we considered potential risks?
This is not being actively used anywhere yet, so minimal risk.

## Images
N/A