### PR TITLE
remove endpoint for 'restoring' a previously 'removed' alias path

### DIFF
--- a/path-manager/app/controllers/PathManagerController.scala
+++ b/path-manager/app/controllers/PathManagerController.scala
@@ -89,11 +89,9 @@ class PathManagerController(override val controllerComponents: ControllerCompone
     }
   }
 
-  def markAliasPathAsRemoved = setAliasPathIsRemovedFlag(true) _
-  def restoreRemovedAliasPath = setAliasPathIsRemovedFlag(false) _
-  private def setAliasPathIsRemovedFlag(isRemoved: Boolean)(path: String)  = Action { request =>
+  def markAliasPathAsRemoved(path: String)  = Action {
 
-    PathStore.setAliasPathIsRemovedFlag(path, isRemoved).fold {
+    PathStore.setAliasPathIsRemovedFlag(path, isRemoved = true).fold {
       PathOperationErrors.increment
       NotFound("no alias path matching the provided path")
     }(

--- a/path-manager/conf/routes
+++ b/path-manager/conf/routes
@@ -3,7 +3,6 @@
 GET     /paths/:id                          controllers.PathManagerController.getPathsById(id: Long)
 GET     /paths                              controllers.PathManagerController.getPathDetails(path: String)
 
-POST    /aliasPath                          controllers.PathManagerController.restoreRemovedAliasPath(path: String)
 DELETE  /aliasPath                          controllers.PathManagerController.markAliasPathAsRemoved(path: String)
 
 POST    /paths                              controllers.PathManagerController.registerNewPath


### PR DESCRIPTION
https://github.com/guardian/path-manager/pull/45 provided a way for alias paths to be 'restored' after being marked as removed (i.e. for accidental removals)… this had raised concerns on the CAPI side and there other ways to resolve this rare use case (by manually creating a frontend redirect)...

## What does this change?
...so in this PR, we remove the `POST` endpoint which supported 'restoring' a previously 'removed' alias path.

## How to test
Unless you have `path-manager` set-up locally with some alias paths (in which case it's self explanatory to test, then it's easiest to test in CODE via the testing instructions in https://github.com/guardian/flexible-content/pull/3685 (which is the refactor PR to mirror this PR).

## How can we measure success?
No notable 'success' to speak of, just a simplification of currently un-used functionality. CAPI team will be happy though 🎉 .

## Have we considered potential risks?
This is not being actively used anywhere yet, so minimal risk.

## Images
N/A
