### PR TITLE
rename `lastModified` field (present on 'alias' PathRecords) to `ceasedToBeCanonicalAt`

### DIFF
--- a/path-manager/app/model/PathRecord.scala
+++ b/path-manager/app/model/PathRecord.scala
@@ -11,7 +11,7 @@ object PathRecord {
       (JsPath \ "identifier").format[Long] and
       (JsPath \ "type").format[String] and
       (JsPath \ "system").format[String] and
-      (JsPath \ "lastModified").formatNullable[Long] and
+      (JsPath \ "ceasedToBeCanonicalAt").formatNullable[Long] and
       (JsPath \ "isRemoved").formatNullable[Boolean]
     )(PathRecord.apply, unlift(PathRecord.unapply))
 
@@ -21,7 +21,7 @@ object PathRecord {
     identifier = item.getLong("identifier"),
     `type` = item.getString("type"),
     system = item.getString("system"),
-    lastModified = if(item.hasAttribute("lastModified")) Some(item.getLong("lastModified")) else None,
+    ceasedToBeCanonicalAt = if(item.hasAttribute("ceasedToBeCanonicalAt")) Some(item.getLong("ceasedToBeCanonicalAt")) else None,
     isRemoved = if(item.hasAttribute("isRemoved")) Some(item.getBoolean("isRemoved")) else None
   )
 }
@@ -31,7 +31,7 @@ case class PathRecord(
   identifier: Long,
   `type`: String,
   system: String,
-  lastModified: Option[Long] = None,
+  ceasedToBeCanonicalAt: Option[Long] = None,
   isRemoved: Option[Boolean] = None
 ) {
 
@@ -42,10 +42,10 @@ case class PathRecord(
       .withString("type", `type`)
       .withString("system", system)
 
-    val intermediateItem = lastModified.fold(
+    val intermediateItem = ceasedToBeCanonicalAt.fold(
       baseItem
     )(
-      baseItem.withLong("lastModified", _)
+      baseItem.withLong("ceasedToBeCanonicalAt", _)
     )
 
     isRemoved.fold(

--- a/path-manager/app/services/PathStore.scala
+++ b/path-manager/app/services/PathStore.scala
@@ -131,7 +131,7 @@ object PathStore extends Logging {
 
   def updateCanonicalWithAlias(newPath: String, id: Long): Either[String, Map[String, List[PathRecord]]] = {
     //This takes the canonical path and makes it an alias. And then adds a new canonical path for newPath.
-    
+
     logger.debug(s"Updating $CANONICAL_PATH_TYPE path [$newPath}] for [$id] and creating $ALIAS_PATH_TYPE to old path.")
 
     if (PathValidator.isInvalid(newPath)) {
@@ -152,7 +152,7 @@ object PathStore extends Logging {
 
           val updatedRecords = if (existingPath != newPath) {
 
-            val newCanonicalRecord = existingRecord.copy(path = newPath, lastModified = None)
+            val newCanonicalRecord = existingRecord.copy(path = newPath, ceasedToBeCanonicalAt = None)
 
             logger.debug(s"Aliasing old path for item [$id]. old path[$existingPath] new path [$newPath]")
             val resultingAliasRecord = PathRecord(
@@ -160,7 +160,7 @@ object PathStore extends Logging {
                 .withPrimaryKey("path", existingPath)
                 .withAttributeUpdate(
                   new AttributeUpdate("type").put(ALIAS_PATH_TYPE),
-                  new AttributeUpdate("lastModified").put(System.currentTimeMillis) // so we can keep the aliases order
+                  new AttributeUpdate("ceasedToBeCanonicalAt").put(System.currentTimeMillis) // so we can keep the aliases order
                 )
                 .withReturnValues(ReturnValue.ALL_NEW) // this means we can call getItem below
               ).getItem

--- a/path-manager/test/services/PathStoreTest.scala
+++ b/path-manager/test/services/PathStoreTest.scala
@@ -76,11 +76,11 @@ class PathStoreTest extends PlaySpec with DockerDynamoTestBase with BeforeAndAft
       )(id => {
 
         PathStore.registerAlias(PathRecord(newPath, id, ALIAS, system))
-        
+
         val paths = PathStore.getPathsById(id)
 
         paths.get(ALIAS).flatMap(_.headOption) shouldBe Some(PathRecord(newPath, id, ALIAS, system))
-        
+
         paths.get(CANONICAL).flatMap(_.headOption) shouldBe Some(PathRecord(firstPath, id, CANONICAL, system))
 
       })
@@ -119,12 +119,12 @@ class PathStoreTest extends PlaySpec with DockerDynamoTestBase with BeforeAndAft
           pathRecord.identifier shouldBe id
           pathRecord.`type` shouldBe ALIAS
           pathRecord.system shouldBe system
-          withClue("alias records should have a lastModified"){ pathRecord.lastModified.isDefined shouldBe true }
+          withClue("alias records should have a ceasedToBeCanonicalAt"){ pathRecord.ceasedToBeCanonicalAt.isDefined shouldBe true }
 
         }
 
         PathStore.getPathDetails(newPath) shouldBe Some(PathRecord(newPath, id, CANONICAL, system))
-        
+
 
       })
 


### PR DESCRIPTION
…to better represent what the timestamp means.

Related https://github.com/guardian/flexible-content/pull/3781 and https://github.com/guardian/flexible-model/pull/35


