### PR TITLE
Moved Xenial AMI to Bionic as it is no longer supported

### DIFF
--- a/path-manager/riff-raff.yaml
+++ b/path-manager/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     app: path-manager
     parameters:
       amiTags:
-        Recipe: editorial-tools-xenial-java8
+        Recipe: editorial-tools-bionic-java8
         AmigoStage: PROD
         BuiltBy: amigo
       amiEncrypted: true


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Moves AMI from Xenial to Bionic because Xenial is no longer supported.

Related card [here](https://trello.com/c/NLpikw2C/2330-update-xenial-amis-to-use-bionic).

## Has it been successfully deployed?

Yes, [here](https://riffraff.gutools.co.uk/deployment/view/1417c754-2bd1-4fd8-a1b4-e5ad271c6aab).
## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Deploy to CODE via RiffRaff (it's under `editorial-tools:path-manager`), and ensure it deploys and runs correctly.