### PR TITLE
Upgrades SBT to 1.5.7 and Scala Play to 2.8.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,18 +4,18 @@ import play.sbt.PlayImport.PlayKeys._
 
 name := "path-manager"
 
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 version := "1.0"
 
-val awsVersion = "1.11.828"
+val awsVersion = "1.12.129"
 
 lazy val dependencies = Seq(
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
   "org.apache.commons" % "commons-lang3" % "3.11",
-  "net.logstash.logback" % "logstash-logback-encoder" % "6.0",
+  "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
   "com.gu" % "kinesis-logback-appender" % "1.4.4",
 
   "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % "test",
@@ -34,7 +34,7 @@ lazy val pathManager = project.in(file("path-manager"))
   .enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin)
   .settings(Defaults.coreDefaultSettings: _*)
   .settings(
-    javaOptions in Universal ++= Seq(
+    Universal / javaOptions ++= Seq(
       "-Dpidfile.path=/dev/null",
       "-J-XX:MaxRAMFraction=2",
       "-J-XX:InitialRAMFraction=2",
@@ -48,17 +48,19 @@ lazy val pathManager = project.in(file("path-manager"))
     maintainer := "Editorial Tools Developers <digitalcms.dev@theguardian.com>",
     packageSummary := description.value,
     packageDescription := description.value,
-    scalaVersion := "2.13.3",
-    scalaVersion in ThisBuild := "2.13.3",
+    scalaVersion := "2.13.7",
+    ThisBuild / scalaVersion := "2.13.7",
     scalacOptions ++= Seq("-feature", "-deprecation", "-language:higherKinds", "-Xfatal-warnings"),
-    doc in Compile := (target.value / "none"),
-    fork in Test := false,
+    Compile / doc := (target.value / "none"),
+    Test / fork := false,
     name := "path-manager",
     playDefaultPort := 10000,
     libraryDependencies ++= dependencies,
-    packageName in Universal := normalizedName.value,
-    topLevelDirectory in Universal := Some(normalizedName.value),
-    riffRaffPackageType := (packageBin in Debian).value,
+    //Necessary to override jackson-databind versions due to AWS and Play incompatibility
+    dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.11.4",
+    Universal / packageName := normalizedName.value,
+    Universal/ topLevelDirectory := Some(normalizedName.value),
+    riffRaffPackageType := (Debian / packageBin).value,
     riffRaffPackageName := name.value,
     riffRaffManifestProjectName := s"editorial-tools:${name.value}",
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.5.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 // The Typesafe repository
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.11")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 


### PR DESCRIPTION
## What does this change?

This PR upgrades the path-manager SBT and Scala Play versions to the latest. This is necessary to mitigate [security issues identified in log4j2](https://github.com/sbt/sbt/releases/tag/v1.5.6).

This PR makes several changes:

- Upgrades SBT to v1.5.7
- Upgrades Scala to 2.13.7
- Upgrades Scala Play to v2.8.11
- Upgrades AWS libraries to v1.12.129
- Upgrades logstash-logback-encoder to v6.6

[Editorial tools working document](https://docs.google.com/document/d/1nVKsXiEXLviHOMY1iQEoyacvN93_SYCQwsOFfaP-dxo/edit#heading=h.67pgv1awhai).

Complexity:
- `jackson-databind` -> AWS libraries and Play were using different version of `jackson-databind`. This was resulting in a runtime error which was overcome via [dependencyOverrides](https://www.scala-sbt.org/1.x/docs/Library-Management.html#Overriding+a+version) SBT feature.

## How to test

We should be able to test this works be deploying the changes to CODE or running locally. This should be a no-op from a user perspective.

## How can we measure success?

path-manager is on the latest security patched versions of core dependencies.
