### PR TITLE
use `editorial-tools-bionic-java8-WITH-cdk-base` amigo recipe

### DIFF
--- a/path-manager/riff-raff.yaml
+++ b/path-manager/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     app: path-manager
     parameters:
       amiTags:
-        Recipe: editorial-tools-bionic-java8
+        Recipe: editorial-tools-bionic-java8-WITH-cdk-base
         AmigoStage: PROD
         BuiltBy: amigo
       amiEncrypted: true


### PR DESCRIPTION
related: #51 

It turns out using `cdk-base` amigo role on the main recipe breaks logging for applications not yet using devx-logging (devx team will investigate, and hopefully this can be reverted sometime soon).