### PR TITLE
Switch to ARM AMI receipe to support graviton instances

### DIFF
--- a/path-manager/riff-raff.yaml
+++ b/path-manager/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     app: path-manager
     parameters:
       amiTags:
-        Recipe: editorial-tools-focal-java8-WITH-cdk-base
+        Recipe: editorial-tools-focal-java8-ARM-WITH-cdk-base
         AmigoStage: PROD
         BuiltBy: amigo
       amiEncrypted: true


### PR DESCRIPTION
## What does this change?

Switches the AMI for this app to an ARM based image. See https://github.com/guardian/editorial-tools-platform/pull/668 for a full description.
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

See related PR
