### PR TITLE
Bump sbt version to get project running on M1 laptops

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.7
+sbt.version=1.7.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,4 +7,15 @@ addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 
 addSbtPlugin("com.github.ehsanyou" % "sbt-docker-compose" % "2.0.0")
 
-libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))
+libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts Artifact("jdeb", "jar", "jar")
+
+/*
+   Because scala-xml has not be updated to 2.x in sbt yet but has in sbt-native-packager
+   See: https://github.com/scala/bug/issues/12632
+
+   This effectively overrides the safeguards (early-semver) put in place by the library authors ensuring binary compatibility.
+   We consider this a safe operation because it only affects the compilation of build.sbt, not of the application build itself
+ */
+libraryDependencySchemes ++= Seq(
+  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+)

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ The path manager exposes the following operations:
 ### Register a new path
 
 To register a new path issue a POST request with ```path``` and ```system``` parameters. This operation will create a new path entry for the path
-requested if the the path is not currently in use. An id is also generated for to identify the object that the path links to,
+requested if the path is not currently in use. An id is also generated for to identify the object that the path links to,
 this id should be stored in the calling system for future operations (this is stored as the internalPageCode in composer and CAPI).
 
 If successful this operation will return an argo JSON response with the paths registered, These are indexed by path type.


### PR DESCRIPTION
## What does this change?
Bumps the sbt version to avoid the `java.lang.UnsatisfiedLinkError … missing compatible architecture` errors we see when running sbt versions < 1.6 on M1 ARM laptops. 

## How to test
Run `sbt compile` on your local laptop. Everything should build as expected.