### PR TITLE
Upgrade to Play 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'corretto'
           cache: 'sbt'
 

--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,9 @@ lazy val dependencies = Seq(
   // See https://github.com/logfellow/logstash-logback-encoder/issues/1005
 
   "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.9" % "test" exclude("com.fasterxml.jackson.module", "jackson-module-jaxb-annotations"),
+
+  // docker-testkit-impl-spotif depends on jnr-unixsocket:0.18, which doesn't support M1 silicon
+  // see https://github.com/spotify/docker-client/pull/1221 (unmerged at present)
   "com.github.jnr" % "jnr-unixsocket" % "0.38.22" % "test" exclude("com.fasterxml.jackson.module", "jackson-module-jaxb-annotations")
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ version := "1.0"
 val awsVersion = "1.12.129"
 
 lazy val dependencies = Seq(
+  "com.github.jnr" % "jnr-unixsocket" % "0.38.22" % "test",
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -6,16 +6,16 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releas
 
 version := "1.0"
 
-val awsVersion = "1.12.129"
+val awsVersion = "1.12.583"
 
 lazy val dependencies = Seq(
   "com.github.jnr" % "jnr-unixsocket" % "0.38.22" % "test",
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
-  "org.apache.commons" % "commons-lang3" % "3.11",
-  "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
-  "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % "test",
+  "org.apache.commons" % "commons-lang3" % "3.14.0",
+  "net.logstash.logback" % "logstash-logback-encoder" % "7.3",
+  "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % "test",
   "com.whisk" %% "docker-testkit-scalatest" % "0.9.9" % "test",
   "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.9" % "test"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-addCommandAlias("dist", ";riffRaffArtifact")
-
 import play.sbt.PlayImport.PlayKeys._
 
 name := "path-manager"

--- a/build.sbt
+++ b/build.sbt
@@ -53,8 +53,6 @@ lazy val pathManager = project.in(file("path-manager"))
     name := "path-manager",
     playDefaultPort := 10000,
     libraryDependencies ++= dependencies,
-    //Necessary to override jackson-databind versions due to AWS and Play incompatibility
-    dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.11.4",
     Universal / packageName := normalizedName.value,
     Universal/ topLevelDirectory := Some(normalizedName.value),
   )

--- a/build.sbt
+++ b/build.sbt
@@ -9,16 +9,27 @@ version := "1.0"
 val awsVersion = "1.12.583"
 
 lazy val dependencies = Seq(
-  "com.github.jnr" % "jnr-unixsocket" % "0.38.22" % "test",
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
   "org.apache.commons" % "commons-lang3" % "3.14.0",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.3",
-  "javax.xml.bind" % "jaxb-api" % "2.3.1", // todo: why is this needed?
   "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % "test",
   "com.whisk" %% "docker-testkit-scalatest" % "0.9.9" % "test",
-  "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.9" % "test"
+
+  // By default, logstash-logback-encoder will tell jackson to dynamically discover all available jackson modules
+  // on the classpath by calling objectMapper.findAndRegisterModules()
+  // If jackson-module-jaxb-annotations is on the classpath, jackson will try to register it and fail because
+  // javax.xml.bind:jaxb-api is missing. This was not an issue before Java 9, because javax.xml.bind:jaxb-api was
+  // included in the JDK
+  //
+  // The options to solve this were either to add javaxb-api as a dependency, or to exclude jackson-module-jaxb-annotations.
+  // We chose the latter because it is a smaller change and does not introduce a new dependency.
+  //
+  // See https://github.com/logfellow/logstash-logback-encoder/issues/1005
+
+  "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.9" % "test" exclude("com.fasterxml.jackson.module", "jackson-module-jaxb-annotations"),
+  "com.github.jnr" % "jnr-unixsocket" % "0.38.22" % "test" exclude("com.fasterxml.jackson.module", "jackson-module-jaxb-annotations")
 )
 
 enablePlugins(DockerCompose)

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ lazy val dependencies = Seq(
   "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
   "org.apache.commons" % "commons-lang3" % "3.14.0",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.3",
+  "javax.xml.bind" % "jaxb-api" % "2.3.1", // todo: why is this needed?
   "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % "test",
   "com.whisk" %% "docker-testkit-scalatest" % "0.9.9" % "test",
   "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.9" % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,6 @@ lazy val pathManager = project.in(file("path-manager"))
       "-J-XX:MaxMetaspaceSize=500m",
       "-J-XX:+UseConcMarkSweepGC",
       "-J-XX:+PrintGCDetails",
-      "-J-XX:+PrintGCDateStamps",
       s"-J-Xloggc:/var/log/${packageName.value}/gc.log"
     ),
     debianPackageDependencies := Seq("java11-runtime-headless"),

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ lazy val pathManager = project.in(file("path-manager"))
       "-J-XX:+PrintGCDateStamps",
       s"-J-Xloggc:/var/log/${packageName.value}/gc.log"
     ),
-    debianPackageDependencies := Seq("openjdk-8-jre-headless"),
+    debianPackageDependencies := Seq("java11-runtime-headless"),
     maintainer := "Editorial Tools Developers <digitalcms.dev@theguardian.com>",
     packageSummary := description.value,
     packageDescription := description.value,

--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,6 @@ lazy val dependencies = Seq(
   "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
   "org.apache.commons" % "commons-lang3" % "3.11",
   "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
-  "ch.qos.logback" % "logback-core" % "1.2.7",
-  "ch.qos.logback" % "logback-classic" % "1.2.7",
   "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % "test",
   "com.whisk" %% "docker-testkit-scalatest" % "0.9.9" % "test",
   "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.9" % "test"

--- a/path-manager/app/services/Dynamo.scala
+++ b/path-manager/app/services/Dynamo.scala
@@ -5,7 +5,7 @@ import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.dynamodbv2.document.{DynamoDB, Item}
 import com.amazonaws.services.dynamodbv2.model._
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBClientBuilder}
-import play.api.{Logger, Logging}
+import play.api.Logging
 
 object Dynamo extends AwsInstanceTags with Logging {
 

--- a/path-manager/app/services/Metrics.scala
+++ b/path-manager/app/services/Metrics.scala
@@ -3,7 +3,7 @@ package services
 import java.util.Date
 import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
 
-import akka.actor.{Actor, ActorSystem, Props}
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
 import com.amazonaws.services.cloudwatch.model._
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.3
+sbt.version=1.9.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 // The Typesafe repository
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.11")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
 
 addSbtPlugin("com.github.ehsanyou" % "sbt-docker-compose" % "2.0.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,14 +3,3 @@ addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
 addSbtPlugin("com.github.ehsanyou" % "sbt-docker-compose" % "2.0.0")
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts Artifact("jdeb", "jar", "jar")
-
-/*
-   Because scala-xml has not be updated to 2.x in sbt yet but has in sbt-native-packager
-   See: https://github.com/scala/bug/issues/12632
-
-   This effectively overrides the safeguards (early-semver) put in place by the library authors ensuring binary compatibility.
-   We consider this a safe operation because it only affects the compilation of build.sbt, not of the application build itself
- */
-libraryDependencySchemes ++= Seq(
-  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
-)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,3 @@
-// The Typesafe repository
-resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
-
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
 
 addSbtPlugin("com.github.ehsanyou" % "sbt-docker-compose" % "2.0.0")

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     app: path-manager
     parameters:
       amiTags:
-        Recipe: editorial-tools-focal-java8-ARM-WITH-cdk-base
+        Recipe: editorial-tools-focal-java11-ARM-WITH-cdk-base
         AmigoStage: PROD
         BuiltBy: amigo
       amiEncrypted: true


### PR DESCRIPTION
## What does this change?

Upgrades from to Play 2.8 to Play 3.0 including change from Akka to Pekko.

This requires an upgrade to SBT 1.9.6 and Java 11. Upgrading to Java 11 caused a strange issue related to Logstash and Jackson, requiring us to explicitly exclude jackson-module-jaxb-annotations. See the [long comment in build.sbt](https://github.com/guardian/path-manager/commit/1ef57a2ef039e21388d5cb94e5308734fcad70a5#diff-5634c415cd8c8504fdb973a3ed092300b43c4b8fc1e184f7249eb29a55511f91R20) for a full explanation.

In addition, this bumps various dependencies and does some spring cleaning of `build.sbt` and `plugins.sbt`.

Finally, the tests were not working on M1 macbooks, which has been resolved by adding an explicit test dependency on a newer version jnr-unixsocket. See https://github.com/spotify/docker-client/pull/1221 (unmerged and unreleased at present).

## How to test

Deploy to code, check that you can still publish new articles in CODE composer