### PR TITLE
Update documentation about populating CODE with PROD data

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -202,9 +202,11 @@ You can access [https://pathmanager-db.local.dev-gutools.co.uk/shell/](pathmanag
 
 Please see [/migrator/readme.md](migrator/readme.md).
 
-## Populate CODE with PROD data
+## Database backups
 
-Path manager is backed by a DynamoDB database. You can restore a backup to a new database table using AWS Backup. See [here](https://docs.aws.amazon.com/aws-backup/latest/devguide/restoring-dynamodb.html) for instructions on how to do this.
+Path manager stores its data in a DynamoDB database. It is backed up daily using [AWS Backup](https://docs.aws.amazon.com/aws-backup/latest/devguide/whatisbackup.html).
+
+If you need PROD data in CODE, you can restore a backup to a new database table. See [this guide](https://docs.aws.amazon.com/aws-backup/latest/devguide/restoring-dynamodb.html) for instructions on how to do this.
 
 ## Argo JSON 
 

--- a/readme.md
+++ b/readme.md
@@ -206,7 +206,7 @@ Please see [/migrator/readme.md](migrator/readme.md).
 
 Path manager stores its data in a DynamoDB database. It is backed up daily using [AWS Backup](https://docs.aws.amazon.com/aws-backup/latest/devguide/whatisbackup.html).
 
-If you need PROD data in CODE, you can restore a backup to a new database table. See [this guide](https://docs.aws.amazon.com/aws-backup/latest/devguide/restoring-dynamodb.html) for instructions on how to do this.
+If you need PROD data in CODE, you can restore a backup to a new database table. See [this guide](https://docs.aws.amazon.com/aws-backup/latest/devguide/restoring-dynamodb.html) for instructions on how to do this. You will first need to login to the "Composer" aws account through [janus](https://janus.gutools.co.uk/).
 
 ## Argo JSON 
 

--- a/readme.md
+++ b/readme.md
@@ -202,20 +202,9 @@ You can access [https://pathmanager-db.local.dev-gutools.co.uk/shell/](pathmanag
 
 Please see [/migrator/readme.md](migrator/readme.md).
 
-## Refreshing from PROD
+## Populate CODE with PROD data
 
-Occassionally there will be a need to refresh the path manager instance in a pre-prod stage with data from production.
-
-The pathmanager is backed by a DynamoDB database. To import/export data from it, use AWS Data Pipeline. See [here](http://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-importexport-ddb.html) for instructions on how to do this. Some notes:
- - Before starting, increase the read/write throughput of the table you are exporting/importing from. e.g. if exporting then increase the number of read capacity units to 500 for both the table and index.
- - When creating the pipeline, set DynamoDB write throughput ratio to 0.95 (this is why we increase the throughput)
- - For success/failure alerts, there's an sns topic called 'pipelinestatus' which you can link to your email address
- - Exporting from the PROD table with 2 m3.xlarge instances took less than 10 minutes when I did it. Importing the PROD data set into the CODE with 2 m1.large instances took 3.5 hours.
- - In the resources menu of 'edit in architect'
-   - Increase the timeout to something larger than 2 hours (12 was plenty for me)
-   - Increase the number of instances to 2 (this is what I did, I'm assuming it makes things a bit faster, but it's probably not worth putting it any higher)
-   - If exporting from PROD, I recommend using m3.xlarge instances - this solved some weird errors I was getting (see [here](http://ijin.github.io/blog/2015/07/02/dynamodb-export-with-datapipeline/) (with google translate!) for more details)
-
+Path manager is backed by a DynamoDB database. You can restore a backup to a new database table using AWS Backup. See [here](https://docs.aws.amazon.com/aws-backup/latest/devguide/restoring-dynamodb.html) for instructions on how to do this.
 
 ## Argo JSON 
 


### PR DESCRIPTION
## What does this change?
AWS Data Pipeline is in maintenance mode and is no longer available in the AWS console. The only way to interact with it is via the AWS CLI or API. We now backup Path Manager tables using [AWS Backup](https://docs.aws.amazon.com/aws-backup/latest/devguide/whatisbackup.html). This pr makes a small change to the project README to remove references to AWS Data Pipeline and direct people to using AWS Backup to restore PROD data to a CODE environment.
